### PR TITLE
_safeMint -> _mint in case airdrop target is contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+yarn.lock

--- a/contracts/Akutar.sol
+++ b/contracts/Akutar.sol
@@ -100,7 +100,7 @@ contract Akutar is Ownable, ERC721 {
                 currentId = currentId - maxQuantityWithinThisGrouping;
 
             //Mint thisId
-            _safeMint(addresses[i], currentId);
+            _mint(addresses[i], currentId);
 
             //Increment ID by one.
             currentId++;


### PR DESCRIPTION
the airdrop can be DOS attacked if the airdrop target address is a
contract and doesn't implement ERC721 receiver function, since the
airdrop func call will fail and the owner has to manually remove the
target address

changing safeMint to mint will bypass that restriction

also changed the test code a bit to make sure new tests can be added