### PR TITLE
manifold.xyz suggested changes

### DIFF
--- a/contracts/Akutar.sol
+++ b/contracts/Akutar.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/utils/Strings.sol";
 Akutar.sol
 
 Written by: mousedev.eth
+Contributions by: manifold.xyz
 
 15,000 NFTs in 4 sections
 
@@ -167,6 +168,7 @@ contract Akutar is Ownable, ERC721 {
         override
         returns (string memory)
     {
+        require(_exists(_tokenId), "ERC721Metadata: URI query for nonexistent token");
         return
             string(
                 abi.encodePacked(BASE_URI, Strings.toString(_tokenId), ".json")

--- a/contracts/Akutar.sol
+++ b/contracts/Akutar.sol
@@ -116,7 +116,7 @@ contract Akutar is Ownable, ERC721 {
                 currentId = currentId - maxQuantityWithinThisGrouping;
 
             //Mint thisId
-            _safeMint(addresses[i], currentId);
+            _mint(addresses[i], currentId);
 
             //Increment ID by one.
             currentId++;

--- a/test/Akutar.js
+++ b/test/Akutar.js
@@ -15,7 +15,6 @@ describe("Tests", function () {
     await expect(Akutar.connect(signers[1]).commit('')).to.be.revertedWith('Ownable: caller is not the owner');
     await expect(Akutar.connect(signers[1]).reveal()).to.be.revertedWith('Ownable: caller is not the owner');
     await expect(Akutar.connect(signers[1]).setBaseURI('')).to.be.revertedWith('Ownable: caller is not the owner');
-    await expect(Akutar.connect(signers[1]).setContractURI('')).to.be.revertedWith('Ownable: caller is not the owner');
     await expect(Akutar.connect(signers[1]).updateRoyalties(signers[1].address, 1000)).to.be.revertedWith('Ownable: caller is not the owner');
   })
 
@@ -94,5 +93,21 @@ describe("Tests", function () {
 
     expect(totalSupply).to.equal(15000);
     expect(totalMinted).to.equal(15000);
+
+    // Test token uri
+    await expect(Akutar.tokenURI(15001)).to.be.revertedWith('ERC721Metadata: URI query for nonexistent token');
+
+    expect(await Akutar.tokenURI(1)).to.equal('1.json');
+    await Akutar.setBaseURI('http://test.com/');
+    expect(await Akutar.tokenURI(1)).to.equal('http://test.com/1.json');
   });
+
+  it("Royalty test", async function () {
+    // Test royalties
+    await Akutar.updateRoyalties(signers[1].address, 1000);
+    const royaltyAmount = await Akutar.royaltyInfo(1, 1000);
+    expect(royaltyAmount[0]).to.equal(signers[1].address);
+    expect(royaltyAmount[1]).to.deep.equal(ethers.BigNumber.from(100));
+  })
+
 });


### PR DESCRIPTION
Use actual token ranges in the Grouping for better readability.
Remove unused CONTRACT_URI
Add EIP2981
Revert if tokenURI requested on invalid token
Add provenance hash
Remove redundant committed variable.
Use mint rather than safeMint (cheaper and unecessary to use safeMint)

Add a number of testing (testing negative cases)